### PR TITLE
Remove ruby and package-cloud from dod-package-dev

### DIFF
--- a/dod-package-dev/Dockerfile
+++ b/dod-package-dev/Dockerfile
@@ -28,7 +28,6 @@ RUN apt-get update && apt-get install -y \
 		reprepro \
 		sudo \
 		ubuntu-dev-tools pbuilder \
-		ruby ruby-dev ruby-bundler\
 		--no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
 
@@ -60,8 +59,6 @@ ENV UBUNTUTOOLS_DEBIAN_MIRROR http://httpredir.debian.org/debian
 RUN { \
 	echo "APTCACHEHARDLINK='no'"; \
 } >> ~/.pbuilderrc
-
-RUN gem install --no-rdoc --no-ri package_cloud
 
 COPY scripts /heroku
 RUN /heroku/apt.postgresql.org.sh


### PR DESCRIPTION
The package-cloud gem package does not install on versions of ruby <2.0
so trusty default ruby is not new enough. This results in failures in
auto build:

https://hub.docker.com/r/heroku/dod-package-dev/builds/

This commit removes ruby and the package-cloud gem from the docker
image, as it was included as a convenience. Users can continue to use
the web or host based package-cloud.