### PR TITLE
Add better locale generation

### DIFF
--- a/dod-locales-base-focal-2.23-locales/Dockerfile
+++ b/dod-locales-base-focal-2.23-locales/Dockerfile
@@ -43,6 +43,10 @@ RUN dpkg-reconfigure -f noninteractive locales
 
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
+RUN apt-get --purge --yes remove python3 vim gcc gawk wget autoconf g++ git bison && apt-get autoremove --yes
+
+RUN rm -rf ${HOME}/*.sh ${HOME}/SUPPORTED
+
 # ensure distro is upgraded
 RUN apt-get update && \
     apt-get \

--- a/dod-locales-base-focal-2.23-locales/Dockerfile
+++ b/dod-locales-base-focal-2.23-locales/Dockerfile
@@ -16,7 +16,21 @@ ENV HOME=/root \
 COPY scripts/ ${HOME}
 
 # get all available locales and configure them
-RUN apt-get update && apt-get install --yes locales && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install --yes \
+    locales \
+    gnupg \
+    python3 \
+    vim \
+    gcc \
+    make \
+    gawk \
+    wget \
+    autoconf \
+    g++ \
+    git \
+    xz-utils \
+    bison \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN "${HOME}/localepatch.sh" ${SOURCE_GLIBC_VERSION} ${TARGET_GLIBC_VERSION}
 RUN "${HOME}/locale-gen-patch.sh" ${TARGET_GLIBC_VERSION}
@@ -26,6 +40,8 @@ ENV PATH=/opt/glibc-${TARGET_GLIBC_VERSION}-heroku/bin:$PATH
 RUN locale-gen en_US.UTF-8 && update-locale
 RUN cp ${HOME}/SUPPORTED /etc/locale.gen
 RUN dpkg-reconfigure -f noninteractive locales
+
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # ensure distro is upgraded
 RUN apt-get update && \

--- a/dod-locales-base-focal-2.23-locales/scripts/locale-gen-patch.sh
+++ b/dod-locales-base-focal-2.23-locales/scripts/locale-gen-patch.sh
@@ -14,7 +14,7 @@ index ff9be29..a16bcbe 100755
              fi
         fi
 -       localedef $no_archive -i $input -c -f $charset $locale_alias $locale || :; \
-+       localedef $no_archive -i $input -c -f $charset $locale_alias "/usr/lib/locale/$locale" || :; \
++       /opt/glibc-2.31-heroku/bin/localedef $no_archive -i $input -c -f $charset $locale_alias $locale || :; \
         echo ' done'; \
  done
  echo "Generation complete."

--- a/dod-locales-base-focal-2.23-locales/scripts/localepatch.sh
+++ b/dod-locales-base-focal-2.23-locales/scripts/localepatch.sh
@@ -81,4 +81,5 @@ rm -rf \
   "glibc-${LOCALE_SOURCE_VERSION}" \
   "glibc-${TARGET_VERSION}" \
   "gnu-keyring.gpg" && \
+rm -rf *.xz.sig && \
 rm -rf /var/lib/apt/lists/*

--- a/dod-locales-base-focal-2.23-locales/scripts/localepatch.sh
+++ b/dod-locales-base-focal-2.23-locales/scripts/localepatch.sh
@@ -5,10 +5,8 @@ set -eu -o pipefail
 WORKING_DIR=${HOME}
 LOCALE_SOURCE_VERSION=$1
 TARGET_VERSION=$2
-LOCALE_ARCHIVE=/usr/lib/locale/locale-archive
 
 cd "${WORKING_DIR}" || exit && \
-apt-get update && apt-get install gnupg python3 vim gcc make gawk wget autoconf g++ git xz-utils bison -y && \
 wget "https://ftp.gnu.org/gnu/gnu-keyring.gpg" && \
 wget "https://ftp.gnu.org/gnu/glibc/glibc-${LOCALE_SOURCE_VERSION}.tar.xz" && \
 wget "https://ftp.gnu.org/gnu/glibc/glibc-${LOCALE_SOURCE_VERSION}.tar.xz.sig" && \
@@ -37,16 +35,44 @@ index df0257b..b82e841 100644
                           identification->category[num],
                           category_name[num]);
 EOF
+cat > evil-archive.patch << "EOF"
+diff --git a/locale/programs/localedef.c b/locale/programs/localedef.c
+index d74c5a34..2c771db5 100644
+--- a/locale/programs/localedef.c
++++ b/locale/programs/localedef.c
+@@ -519,10 +519,10 @@ construct_output_path (char *path)
+       ssize_t n;
+       if (normal == NULL)
+        n = asprintf (&result, "%s%s/%s%c", output_prefix ?: "",
+-                     COMPLOCALEDIR, path, '\0');
++                     "/usr/lib/locale", path, '\0');
+       else
+        n = asprintf (&result, "%s%s/%.*s%s%s%c",
+-                     output_prefix ?: "", COMPLOCALEDIR,
++                     output_prefix ?: "", "/usr/lib/locale",
+                      (int) (startp - path), path, normal, endp, '\0');
+
+       if (n < 0)
+diff --git a/locale/programs/locarchive.c b/locale/programs/locarchive.c
+index dccaf04e..012e1dd4 100644
+--- a/locale/programs/locarchive.c
++++ b/locale/programs/locarchive.c
+@@ -57,7 +57,7 @@
+
+ extern const char *output_prefix;
+
+-#define ARCHIVE_NAME COMPLOCALEDIR "/locale-archive"
++#define ARCHIVE_NAME "/usr/lib/locale" "/locale-archive"
+
+ static const char *locnames[] =
+   {
+EOF
 git apply --ignore-space-change --ignore-whitespace patch-localecheck.patch && \
+git apply --ignore-space-change --ignore-whitespace evil-archive.patch && \
 mkdir build && cd build && \
 ../configure --prefix="/opt/glibc-${TARGET_VERSION}-heroku" --disable-werror && \
 make -j "$(nproc)" && make install && \
-mkdir "/opt/glibc-${TARGET_VERSION}-heroku/lib/locale" && \
-"/opt/glibc-${TARGET_VERSION}-heroku"/bin/localedef -i en_US -f UTF-8 /usr/lib/locale/en_US.UTF-8 && \
-
-if [ -f "${LOCALE_ARCHIVE}" ]; then
-  rm "${LOCALE_ARCHIVE}"
-fi && \
+"/opt/glibc-${TARGET_VERSION}-heroku"/bin/localedef -i en_US -f UTF-8 en_US.UTF-8 && \
 
 cd "${WORKING_DIR}" || exit && \
 rm -rf \


### PR DESCRIPTION
Due to some "interesting" quirks on how multiple entries are created by
`locarchive`, which only triggers when an explicit path is _not_ passed
in, we were generating locales that Postgres couldn't find based on the
information stored in `pg_collation`.

To sidestep this, we patch `localedef` and `locarchive` to point
directly to `/usr/lib/locale` (instead of the `glibc`-local directory)
and patch `locale-gen` to use the patched `localedef`.

Ref: GUS-W-9208215