### PR TITLE
maint: split Snyk projects

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -21,6 +21,6 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: "--severity-threshold=high --file=dod-locales-base-${{ matrix.base_flavour }}/Dockerfile"
+          args: "--severity-threshold=high --file=dod-locales-base-${{ matrix.base_flavour }}/Dockerfile --project-name=heroku/dod-locale-base/{{ matrix.base_flavour }}"
           image: "heroku/dod-locale-base:${{ matrix.base_flavour }}"
           command: monitor


### PR DESCRIPTION
Snyk projects get overidden instead of splitting out by image label, so manually split the projects instead.

Ref: [GUS-W-12783667](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001OCbP8YAL/view)